### PR TITLE
Update usage of `Money` to avoid deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.2.7
   - 2.3.4
   - 2.4.1
   - 2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.0.2 (Next)
 
+* [#16](https://github.com/artsy/money_helper/pull/16): Remove deprecation warnings - [@sweir27](https://github.com/sweir27).
 * [#15](https://github.com/artsy/money_helper/pull/15): Added Rubocop - [@dblock](https://github.com/dblock).
 * Your contribution here.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ money_range_to_text(10000, 40000, 'AUD', ' ... ')
 ```
 produces: "AUD $10,000 ... 40,000"
 
+Defaults
+--------
+
+As of [#16](https://github.com/artsy/money_helper/pull/16) this library explicitly specifies the `Money.locale_backend = :currency` default.
+
 Contributing
 ------------
 

--- a/lib/money_helper.rb
+++ b/lib/money_helper.rb
@@ -2,6 +2,7 @@ require 'active_support/core_ext/object/blank'
 require 'money'
 
 module MoneyHelper
+  Money.locale_backend = :currency
   I18n.enforce_available_locales = false
 
   SYMBOL_ONLY = %w[USD GBP EUR MYR].freeze # don't use ISO code
@@ -31,7 +32,7 @@ module MoneyHelper
     symbol = symbol_for_code(currency)
     include_symbol = !number_only && symbol.present? && OK_SYMBOLS.include?(symbol)
     subunit_factor = Money::Currency.new(valid_currency).subunit_to_unit
-    money_options = { no_cents: true, symbol_position: :before, symbol: include_symbol }.merge(options)
+    money_options = { no_cents: true, format: '%u %n', symbol: include_symbol }.merge(options)
     (number_only || SYMBOL_ONLY.include?(currency) ? '' : currency + ' ') +
       Money.new(amount * subunit_factor.ceil, valid_currency).format(money_options).delete(' ')
   end


### PR DESCRIPTION
Before these changes, running specs (or using this gem in other projects) threw the following deprecation warnings:
```
[DEPRECATION] `symbol_position: :before` is deprecated - you can replace it with `format: %u %n`
[DEPRECATION] You are using the default localization behaviour that will change in the next major release. Find out more - https://github.com/RubyMoney/money#deprecation
```