### PR TITLE
restore ability to remove cents from amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### 2.0.1 (Next)
+### 3.0.0 (Next)
 
+* [#27](https://github.com/artsy/money_helper/pull/27): Update `money_to_text` to pass `format` options to `Money#format` for additional features such as `no_cents` - [@agrberg](https://github.com/agrberg).
 * Your contribution here.
 
 ### 2.0.0 (2021-09-20)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,44 @@
+Upgrading MoneyHelper
+=====================
+
+### Upgrading to >= 3.0.0
+
+#### `money_to_text` format options
+
+Prior to 3.0.0 `money_to_text` took a named argument `with_symbol`. The default value was `true` and assing `false` would omit the currency symbol.
+
+This data was later passed to the `Money#format` method with a default `format` string of `'%u%n'`. Users of `MoneyHelper` could not modify the format string or utilize additional format options, such as `no_cents: false`.
+
+In 3.0.0 this was changed so `money_to_text` can take an optional `format` argument which is eventually passed to `Money#format` with only the slight modification of adding in `format: '%u%n'` if this key is not present.
+
+### Upgrading to >= 2.0.0
+
+#### `money_to_text` amount is now given in minor units
+
+Prior to 2.0.0 `money_to_text` took an amount in a currency's major units and converted this value internally before passing to `Money#new` which expects values in their minor unit (i.e. For USD the major unit is Dollars and the minor unit is Cents). This version removes the autoscaling so `money_to_text` can take amounts in their minor units.
+
+Additionally, `currency`, `number_only`, and `options` were removed as postional arguments and replaced with named arguments `currency`, `with_currency`, and `with_symbol` with `'USD'`, `true` and `true` as their default arguments respectively.
+
+One minor difference is that `currency` can be omited completely where as in < 2.0.0 `''` or `nil` was required to be passed for the default of `'USD'` to be used.
+
+Finally the automatic omission of certain currency codes (USD, GBP, EUR, and MYR) is no longer supported. To replicate this behavior you must explicitly specify `with_currency: false`.
+
+The following illustrates the primary difference in usage.
+
+```ruby
+# Before 2.0.0
+
+MoneyHelper.money_to_text(123, 'USD')
+# => $123
+
+# After 2.0.0
+
+MoneyHelper.money_to_text(123) # `currency: 'USD'` is the default
+# => USD $1.23
+
+# to replicate previous behavior almost exactly
+MoneyHelper.money_to_text(12300, with_currency: false)
+# => $123.00
+
+# Note the inclusion of the cents. The ability to remove this was added in 3.0.0 as another breaking change
+```

--- a/lib/money_helper.rb
+++ b/lib/money_helper.rb
@@ -29,16 +29,15 @@ module MoneyHelper
   #   amount_minor: (Integer) amount in minor unit
   #   currency: (String) optional ISO currency code, defaulting to USD
   #   with_currency: (Boolean) optional flag to include ISO currency code, defaulting to true
-  #   with_symbol: (Boolean) optional flag to include currency symbol, defaulting to true
-  def self.money_to_text(amount_minor, currency: 'USD', with_currency: true, with_symbol: true)
+  # 　format: (Hash) optional formatting options to pass to `Money#format` e.g.:
+  #     no_cents: (Boolean) optional flag to exclude cents, defaulting to false
+  #     symbol: (Boolean) optional flag to include currency symbol, defaulting to true
+  def self.money_to_text(amount_minor, currency: 'USD', with_currency: true, format: {})
     return '' if amount_minor.blank?
 
-    money_options = {
-      format: '%u%n',
-      symbol: with_symbol
-    }
+    format_options = { format: '%u%n' }.merge(format)
 
-    formatted_amount = Money.new(amount_minor, currency).format(money_options)
+    formatted_amount = Money.new(amount_minor, currency).format(format_options)
     formatted_currency = with_currency ? currency.upcase : ''
 
     "#{formatted_currency} #{formatted_amount}".strip
@@ -82,7 +81,7 @@ module MoneyHelper
       money_to_text(low, currency: currency)
     else
       formatted_low = money_to_text(low, currency: currency)
-      formatted_high = money_to_text(high, currency: currency, with_currency: false, with_symbol: false)
+      formatted_high = money_to_text(high, currency: currency, with_currency: false, format: { symbol: false })
       [formatted_low, formatted_high].compact.join(delimiter)
     end
   end

--- a/spec/money_helper_spec.rb
+++ b/spec/money_helper_spec.rb
@@ -139,18 +139,23 @@ describe MoneyHelper do
       expect(MoneyHelper.money_to_text(30_175_93, currency: 'AFN', with_currency: false)).to eql('؋30,175.93')
     end
 
-    it 'omits symbol when with_symbol is false' do
-      expect(MoneyHelper.money_to_text(30_175_93, currency: 'EUR', with_symbol: false)).to eql('EUR 30.175,93')
-      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AUD', with_symbol: false)).to eql('AUD 30,175.93')
-      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AMD', with_symbol: false)).to eql('AMD 30,175.93')
-      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AFN', with_symbol: false)).to eql('AFN 30,175.93')
+    it 'omits symbol when `format: symbol:` is false' do
+      expect(MoneyHelper.money_to_text(30_175_93, currency: 'EUR', format: { symbol: false })).to eql('EUR 30.175,93')
+      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AUD', format: { symbol: false })).to eql('AUD 30,175.93')
+      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AMD', format: { symbol: false })).to eql('AMD 30,175.93')
+      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AFN', format: { symbol: false })).to eql('AFN 30,175.93')
     end
 
-    it 'omits ISO code and symbol when both with_currency and with_symbol are false' do
-      expect(MoneyHelper.money_to_text(30_175_93, currency: 'EUR', with_currency: false, with_symbol: false)).to eql('30.175,93')
-      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AUD', with_currency: false, with_symbol: false)).to eql('30,175.93')
-      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AMD', with_currency: false, with_symbol: false)).to eql('30,175.93')
-      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AFN', with_currency: false, with_symbol: false)).to eql('30,175.93')
+    it 'omits ISO code and symbol when both `with_currency` and `format: symbol:` are false' do
+      expect(MoneyHelper.money_to_text(30_175_93, currency: 'EUR', with_currency: false, format: { symbol: false })).to eql('30.175,93')
+      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AUD', with_currency: false, format: { symbol: false })).to eql('30,175.93')
+      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AMD', with_currency: false, format: { symbol: false })).to eql('30,175.93')
+      expect(MoneyHelper.money_to_text(30_175_93, currency: 'AFN', with_currency: false, format: { symbol: false })).to eql('30,175.93')
+    end
+
+    it 'omits cents when `format: no_cents:` is true' do
+      expect(MoneyHelper.money_to_text(30_175_93, with_currency: false, format: { no_cents: true, symbol: false })).to eql('30,175')
+      expect(MoneyHelper.money_to_text(30_175_93, currency: 'EUR', with_currency: false, format: { no_cents: true, symbol: false })).to eql('30.175')
     end
 
     it 'returns an empty string if amount passed in is whitespace, empty string, or nil' do


### PR DESCRIPTION
I wasn't able to find an explicit reason to remove this feature when making the breaking change in https://github.com/artsy/money_helper/pull/20 so I'm adding it back as another library depends on the `no_cents` option to `Money#format`.