### PR TITLE
chore: Update current gem version

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MoneyHelper
-  VERSION = '2.0.0'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
Updating the gem version to the newly published [3.0](https://rubygems.org/gems/money_helper)