### PR TITLE
feat: Add with_currency support to money range method

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -13,7 +13,7 @@ appraise 'activesupport_61' do
 end
 
 appraise 'activesupport_edge' do
-  git 'https://github.com/rails/rails.git' do
+  git 'https://github.com/rails/rails.git', branch: 'main' do
     gem 'activesupport', require: 'active_support'
   end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -13,7 +13,7 @@ appraise 'activesupport_61' do
 end
 
 appraise 'activesupport_edge' do
-  git 'git://github.com/rails/rails.git' do
+  git 'https://github.com/rails/rails.git' do
     gem 'activesupport', require: 'active_support'
   end
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-### 3.0.0 (Next)
+### 3.0.1 (Next)
+
+* [#29](https://github.com/artsy/money_helper/pull/29): Update `money_range_to_text` to receive `with_currency` parameter for optional ISO code printing - [@leamotta](https://github.com/leamotta).
+* Your contribution here.
+
+### 3.0.0 (2022-02-16)
 
 * [#27](https://github.com/artsy/money_helper/pull/27): Update `money_to_text` to pass `format` options to `Money#format` for additional features such as `no_cents` - [@agrberg](https://github.com/agrberg).
-* Your contribution here.
 
 ### 2.0.0 (2021-09-20)
 

--- a/gemfiles/activesupport_edge.gemfile
+++ b/gemfiles/activesupport_edge.gemfile
@@ -4,7 +4,7 @@
 
 source 'http://rubygems.org'
 
-git 'git://github.com/rails/rails.git' do
+git 'https://github.com/rails/rails.git', branch: 'main' do
   gem 'activesupport', require: 'active_support'
 end
 

--- a/lib/money_helper.rb
+++ b/lib/money_helper.rb
@@ -70,17 +70,18 @@ module MoneyHelper
   #   high: (Integer) amount in minor unit
   #   currency: (String) optional ISO currency code, defaulting to USD
   #   delimiter: (String) optional
-  def self.money_range_to_text(low, high, currency: 'USD', delimiter: ' - ')
+  #   with_currency: (Boolean) optional flag to include ISO currency code, defaulting to true
+  def self.money_range_to_text(low, high, currency: 'USD', delimiter: ' - ', with_currency: true)
     if low.blank? && high.blank?
       ''
     elsif low.blank?
-      "Under #{money_to_text(high, currency: currency)}"
+      "Under #{money_to_text(high, currency: currency, with_currency: with_currency)}"
     elsif high.blank?
-      "#{money_to_text(low, currency: currency)} and up"
+      "#{money_to_text(low, currency: currency, with_currency: with_currency)} and up"
     elsif low == high
-      money_to_text(low, currency: currency)
+      money_to_text(low, currency: currency, with_currency: with_currency)
     else
-      formatted_low = money_to_text(low, currency: currency)
+      formatted_low = money_to_text(low, currency: currency, with_currency: with_currency)
       formatted_high = money_to_text(high, currency: currency, with_currency: false, format: { symbol: false })
       [formatted_low, formatted_high].compact.join(delimiter)
     end

--- a/spec/money_helper_spec.rb
+++ b/spec/money_helper_spec.rb
@@ -205,12 +205,24 @@ describe MoneyHelper do
       expect(MoneyHelper.money_range_to_text(nil, 40_983_27, currency: 'USD')).to eql('Under USD $40,983.27')
     end
 
+    it "prefixes the text 'Under ' when low amount not given and omits ISO code when with_currency is false" do
+      expect(MoneyHelper.money_range_to_text(nil, 40_983_27, currency: 'USD', with_currency: false)).to eql('Under $40,983.27')
+    end
+
     it "appends the text ' and up' when high amount not given" do
       expect(MoneyHelper.money_range_to_text(30_175_93, nil, currency: 'USD')).to eql('USD $30,175.93 and up')
     end
 
+    it "appends the text ' and up' when high amount not given and omits ISO code when with_currency is false" do
+      expect(MoneyHelper.money_range_to_text(30_175_93, nil, currency: 'USD', with_currency: false)).to eql('$30,175.93 and up')
+    end
+
     it 'treats as a single price when low amount and high amount are identical' do
       expect(MoneyHelper.money_range_to_text(30_175_93, 30_175_93, currency: 'USD')).to eql('USD $30,175.93')
+    end
+
+    it 'treats as a single price when low amount and high amount are identical and omits ISO code when with_currency is false' do
+      expect(MoneyHelper.money_range_to_text(30_175_93, 30_175_93, currency: 'USD', with_currency: false)).to eql('$30,175.93')
     end
 
     it 'returns empty string when both amounts are nil' do

--- a/spec/money_helper_spec.rb
+++ b/spec/money_helper_spec.rb
@@ -217,6 +217,12 @@ describe MoneyHelper do
       expect(MoneyHelper.money_range_to_text(nil, nil, currency: 'USD')).to eql('')
     end
 
+    it 'omits ISO code when with_currency is false' do
+      expect(MoneyHelper.money_range_to_text(30_175_93, 40_983_27, currency: 'EUR', with_currency: false)).to eql('€30.175,93 - 40.983,27')
+      expect(MoneyHelper.money_range_to_text(30_175_93, 40_983_27, currency: 'AUD', with_currency: false)).to eql('$30,175.93 - 40,983.27')
+      expect(MoneyHelper.money_range_to_text(30_175_93, 40_983_27, currency: 'AMD', with_currency: false)).to eql('դր.30,175.93 - 40,983.27')
+    end
+
     it "raises an exception when currency can't be found" do
       expect do
         MoneyHelper.money_range_to_text(10_000, 20_000, currency: 'ITL')


### PR DESCRIPTION
Currently there is no way to avoid printing the ISO code whenever we use the `money_range_to_text` method. This PR adds that functionality back, which was lost during the upgrade to [version 2](https://github.com/artsy/money_helper/blob/main/UPGRADING.md#upgrading-to--200)